### PR TITLE
Using 'AddressObject' directly

### DIFF
--- a/lib/postal-address.ts
+++ b/lib/postal-address.ts
@@ -47,7 +47,7 @@ class PostalAddress implements PostalAddressInterface {
     [key: string]: ParserInterface
   }
 
-  public constructor() {
+  public constructor(initialObject?: AddressObject) {
     // Possible values: 'array' | 'string'
     this.outputFormat = 'array'
     // 2-letter country code
@@ -57,7 +57,7 @@ class PostalAddress implements PostalAddressInterface {
     // Transform input data or keep it as is
     this.useTransforms = true
     // The object properties that can be set
-    this.object = { ...objectInitialState }
+    this.object = { ...objectInitialState, ...initialObject }
     // Validator functions
     this.validators = {
       formatForCountry: (value) =>

--- a/lib/types/address-format.ts
+++ b/lib/types/address-format.ts
@@ -6,7 +6,31 @@ export interface AddFormatArgs {
 }
 
 export interface AddressObject {
-  [key: string]: string
+  address1: string;
+  address2: string;
+  addressNum: string;
+  city: string;
+  companyName: string;
+  country: string;
+  countryAlpha2: string;
+  do: string;
+  dong: string;
+  firstLastName: string;
+  firstName: string;
+  gu: string;
+  honorific: string;
+  jobTitle: string;
+  lastName: string;
+  postalCode: string;
+  prefecture: string;
+  province: string;
+  region: string;
+  republic: string;
+  secondLastName: string;
+  secondName: string;
+  si: string;
+  state: string;
+  title: string;
 }
 
 export interface TransformFunction {


### PR DESCRIPTION
- [x] Typing `AddressObject`
- [x] Letting someone bring their own `AddressObject`
- [ ] Exporting `AddressObject` type (please help @joaocarmo)

This is all in the effort to allow me to pull a stored address, dump it into a `new PostalAddress(...)`, and format it without having to `setAddress``(...); setCity(...); ...`