### PR TITLE
Expand address formats with additional countries

### DIFF
--- a/lib/address-formats.ts
+++ b/lib/address-formats.ts
@@ -33,6 +33,33 @@ const addressFormats: AddressFormats = {
       ],
     },
   },
+  // Austria
+  AT: {
+    default: {
+      array: [
+        ['honorific'],
+        ['firstName', 'secondName', 'lastName'],
+        ['companyName'],
+        ['address1'],
+        ['address2'],
+        ['postalCode', 'city'],
+        ['country'],
+      ],
+    },
+  },
+  // The Bahamas
+  BS: {
+    default: {
+      array: [
+        ['honorific', 'firstName', 'secondName', 'lastName'],
+        ['companyName'],
+        ['address1'],
+        ['address2'],
+        ['city'],
+        ['country'],
+      ],
+    },
+  },
   // Bulgaria
   BG: {
     default: {
@@ -386,6 +413,19 @@ const addressFormats: AddressFormats = {
         ['companyName'],
         ['lastName'],
         ['firstName', 'secondName'],
+      ],
+    },
+  },
+  // Singapore
+  SG: {
+    default: {
+      array: [
+        ['honorific', 'firstName', 'secondName', 'lastName'],
+        ['companyName'],
+        ['address1'],
+        ['address2'],
+        ['country', 'postalCode'],
+        ['country'],
       ],
     },
   },


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

This PR adds Singapore, Austria, and the Bahamas to the list of formatted countries

### Change description

`addressFormats` is missing a few countries. Here are some references for how these countries format their addresses:
https://www.lingonomad.com/blogs/singapore/address-format
https://youbianku.com/files/upu/BHS.pdf
https://youbianku.com/files/upu/AUT.pdf

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [ ] Tests passed
- [ ] Coding style respected
