### PR TITLE
package supports ESM import declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "./dist/postal-address.node.js",
   "exports": {
     ".": {
+      "import": "./dist/postal-address.js",
       "browser": "./dist/postal-address.js",
       "require": "./dist/postal-address.node.js"
     },


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

This allows projects using ESM import declarations to import `PostalAddress` as usual if they choose to upgrade to the latest version. 

### Change description

<!-- Please replace {Please write here ...} with something useful -->

After `v0.4.3` this ability was removed.  Without this, this error is returned on our end:

```
Compiled with problems:

Module not found: Error: Package path . is not exported from package
/../node_modules/i18n-postal-address (see exports field in /../node_modules/i18n-postal-address/package.json
```

We'd like to be able to use the latest version of this package when it becomes available and without this line in the `package.json` file I'm unable to see the new countries added to `address-formats.ts`
### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed
- [x] Coding style respected
