### PR TITLE
bugfix: bulgarian address convention

### DIFF
--- a/lib/address-formats.ts
+++ b/lib/address-formats.ts
@@ -64,13 +64,12 @@ const addressFormats: AddressFormats = {
   BG: {
     default: {
       array: [
-        ['country'],
-        ['state'],
-        ['postalCode', 'city'],
-        ['address1'],
-        ['address2'],
         ['companyName'],
         ['honorific', 'firstName', 'secondName', 'lastName'],
+        ['address1', 'address2'],
+        ['postalCode', 'city'],
+        ['state'],
+        ['country'],
       ],
     },
   },


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

In light of some research, I believe the Bulgarian localization is inaccurate: https://e-snail.com/how-to-send-a-letter-to-bulgaria/

### Change description

Adjust to meet following description:
Recipient’s Name: Begin with the full name of the recipient on the first line.
Street Name and Number: Follow with the thoroughfare and the number of the residence.
Apartment or Suite Number: If applicable, include this on the same line after the building number, separated by a comma.
Town or City: Write the name of the local town or city.
Postal Code: Place the four-digit postal code before the town or city name.
Country Name: Conclude with the country name “BULGARIA” in capital letters.

Example of a Bulgarian Address:
```
Ivan Ivanov
ul. “Tsarigradsko shose” 47A, Apt. 56
1113 SOFIA
BULGARIA
```

### Check lists

- [ ] Tests passed
- [X] Coding style respected
