### PR TITLE
adjust for Korea, allow propagation of province to state

### DIFF
--- a/lib/__tests__/postal-address.test.ts
+++ b/lib/__tests__/postal-address.test.ts
@@ -342,4 +342,15 @@ describe('Propagation', () => {
     expect(myAddress.toObject().lastName).toBe('Doe')
     expect(myAddress.toObject().secondLastName).toBe('Smith')
   })
+
+  it('Propagation of changes to related properties overwrites with latest invoked even if both present', () => {
+    const myAddress = new PostalAddress()
+
+    myAddress.setCity('City')
+    myAddress.setSi('Si')
+    expect(myAddress.toObject().si).toBe('Si')
+    expect(myAddress.toObject().city).toBe('Si')
+
+    myAddress.setPropagation(false)
+  })
 })

--- a/lib/address-formats.ts
+++ b/lib/address-formats.ts
@@ -291,10 +291,10 @@ const addressFormats: AddressFormats = {
   KR: {
     default: {
       array: [
-        ['country'],
-        ['do', 'si', 'dong', 'gu', 'addressNum'],
-        ['companyName'],
         ['lastName', 'firstName', 'honorific'],
+        ['companyName'],
+        ['do', 'si', 'dong', 'gu', 'addressNum'],
+        ['postalCode', 'country'],
       ],
     },
   },

--- a/lib/postal-address.ts
+++ b/lib/postal-address.ts
@@ -282,6 +282,7 @@ class PostalAddress implements PostalAddressInterface {
 
     if (this.propagateToRelatedProperties) {
       this.setProperty('do', newValue)
+      this.setProperty('state', newValue)
     }
     return this
   }
@@ -321,6 +322,10 @@ class PostalAddress implements PostalAddressInterface {
 
   public setState(newValue: string): this {
     this.setProperty('state', newValue)
+
+    if (this.propagateToRelatedProperties) {
+      this.setProperty('province', newValue)
+    }
     return this
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

#226 
- [ ] Chore
- [ ] Feature
- [X] Fix
- [ ] Refactor
- [X] Tests
- [ ] Documentation

### Summary

- correct Korean address based on discussion
- account for the fact that province/state never clash and propagate to both

### Change description

- adjust Korean address
- add test to make propagation logic more explicit
- propagate between province and state

### Check lists

- [ ] Tests passed
- [ ] Coding style respected
