### PR TITLE
refactor: remove deprecated methods from PostalAddress

### DIFF
--- a/lib/postal-address.ts
+++ b/lib/postal-address.ts
@@ -290,36 +290,6 @@ class PostalAddress implements PostalAddressInterface {
     return this
   }
 
-  /** @deprecated Use `setGivenName` instead */
-  public setFirstName(newValue: string): this {
-    return this.setGivenName(newValue)
-  }
-
-  /** @deprecated Use `setFamilyName` instead */
-  public setLastName(newValue: string): this {
-    return this.setFamilyName(newValue)
-  }
-
-  /** @deprecated Use `setAdditionalName` instead */
-  public setSecondName(newValue: string): this {
-    return this.setAdditionalName(newValue)
-  }
-
-  /** @deprecated Use `setFirstFamilyName` instead */
-  public setFirstLastName(newValue: string): this {
-    return this.setFirstFamilyName(newValue)
-  }
-
-  /** @deprecated Use `setSecondFamilyName` instead */
-  public setSecondLastName(newValue: string): this {
-    return this.setSecondFamilyName(newValue)
-  }
-
-  /** @deprecated Use `setHonorificPrefix` instead */
-  public setHonorific(newValue: string): this {
-    return this.setHonorificPrefix(newValue)
-  }
-
   public setFormat({
     country,
     type,

--- a/lib/types/postal-address.ts
+++ b/lib/types/postal-address.ts
@@ -56,17 +56,4 @@ export default interface PostalAddressInterface {
   toArray(): AddressOutputFormat
   toObject(): AddressObject
   toString(): string
-
-  /** @deprecated Use `setGivenName` instead */
-  setFirstName(newValue: string): this
-  /** @deprecated Use `setFamilyName` instead */
-  setLastName(newValue: string): this
-  /** @deprecated Use `setAdditionalName` instead */
-  setSecondName(newValue: string): this
-  /** @deprecated Use `setFirstFamilyName` instead */
-  setFirstLastName(newValue: string): this
-  /** @deprecated Use `setSecondFamilyName` instead */
-  setSecondLastName(newValue: string): this
-  /** @deprecated Use `setHonorificPrefix` instead */
-  setHonorific(newValue: string): this
 }


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Chore
- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

Remove the 6 deprecated method aliases added in #362 as transitional shims. Since the next is a breaking release (ESM-only, new constructor, removed libpostal), there's no value in carrying deprecated aliases.

### Change description

Removed from class and interface:

| Removed method | Replacement |
|----------------|-------------|
| `setFirstName` | `setGivenName` |
| `setLastName` | `setFamilyName` |
| `setSecondName` | `setAdditionalName` |
| `setFirstLastName` | `setFirstFamilyName` |
| `setSecondLastName` | `setSecondFamilyName` |
| `setHonorific` | `setHonorificPrefix` |

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed
- [x] Coding style respected